### PR TITLE
skip reproducible assembly task when prependShellScript is set

### DIFF
--- a/src/main/scala/AssemblyHelpers.scala
+++ b/src/main/scala/AssemblyHelpers.scala
@@ -10,7 +10,18 @@ object AssemblyHelpers {
 
   val settings: Seq[Setting[_]] =
     Seq(
-      assembly := ReproducibleBuildsPlugin.postProcessJar(assembly.value)
-    )
+      assembly := {
+        val log = streams.value.log
+        val jar = assembly.value
+        val options = (assemblyOption in assembly).value
 
+        if (options.prependShellScript.isDefined) {
+          log.warn("Cannot make assembly reproducible when prependShellScript is set")
+          jar
+        }
+        else {
+          ReproducibleBuildsPlugin.postProcessJar(jar)
+        }
+      }
+    )
 }


### PR DESCRIPTION
prependShellScript is creating non-zip file which reproducible plugin cannot strip.

relates #155 