### PR TITLE
Don't cross-publish for multiple sbt versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,13 @@ sudo: false
 language: scala
 jdk: openjdk8
 script:
-  - sbt ^test scripted ^publishLocal
-  - md5sum target/scala-*/sbt-*/stripped/sbt-reproducible-builds-*.jar
+  - sbt test scripted publishLocal
 
 deploy:
   provider: script
   skip_cleanup: true
   script:
-    - openssl aes-256-cbc -K $encrypted_2b1ceb155314_key -iv $encrypted_2b1ceb155314_iv -in private.key.enc -out .travis/private.key -d && gpg --allow-secret-key-import --import .travis/private.key .travis/public.key && sbt ^publish
+    - openssl aes-256-cbc -K $encrypted_2b1ceb155314_key -iv $encrypted_2b1ceb155314_iv -in private.key.enc -out .travis/private.key -d && gpg --allow-secret-key-import --import .travis/private.key .travis/public.key && sbt publish
   on:
     tags: true
     repo: raboof/sbt-reproducible-builds

--- a/build.sbt
+++ b/build.sbt
@@ -2,13 +2,12 @@ sbtPlugin := true
 
 organization := "net.bzzt"
 
-scalaVersion := "2.13.5"
+scalaVersion := "2.12.12"
 
 /**
- * Don't build for 0.13, since that does not include
- * gigahorse to perform uploads.
+ * should work with later sbt versions as well (tested at least with 1.4.x)
  */
-crossSbtVersions := Vector(/*"0.13.16",*/ "1.2.7")
+sbtVersion := "1.2.7"
 
 val sbtPgpVersion = "1.1.2"
 


### PR DESCRIPTION
1.2-1.4 seem compatible enough, and `^` overwrites the Scala version.