### PR TITLE
Add scalafix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,5 +11,7 @@ jobs:
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
+      - name: 'Linter: Scalafix checks'
+        run: sbt "scalafixAll --check"
       - uses: olafurpg/setup-scala@v10
       - run: sbt test scripted publishLocal

--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,30 @@
+rules = [
+  DisableSyntax, # Disables some constructs that make no semantic sense like `final val`
+  ProcedureSyntax, # Procedure syntax in Scala is always discouraged
+  NoValInForComprehension, # `val` in for comprehensions are deprecated and shouldn't be used
+  NoAutoTupling, # Avoids the automatic tupling in parameters
+  RemoveUnused, # Removes unused elements
+  LeakingImplicitClassVal, # This rule adds the private access modifier on the field of implicit value classes in order to prevent direct access.
+  OrganizeImports # Organizes imports and removes unused ones
+]
+
+ExplicitResultTypes.memberKind = [Def, Val, Var]
+ExplicitResultTypes.memberVisibility = [Public, Protected]
+ExplicitResultTypes.skipSimpleDefinitions = ['Lit', 'Term.New', 'Term.Ref']
+ExplicitResultTypes.fatalWarnings = true
+DisableSyntax.noReturns = true
+DisableSyntax.noWhileLoops = true
+DisableSyntax.noXml = true
+DisableSyntax.noFinalVal = true
+DisableSyntax.noFinalize = true
+DisableSyntax.noValPatterns = true
+RemoveUnused.imports = false # The plugin organize imports removes unused and clashes with this
+OrganizeImports {
+    groupedImports = Merge
+    groups = [
+        "*"
+        "java."
+        "scala."
+        "re:javax?\\."
+      ] # Reasoning for this config is to keep the more business related imports at the top, while language imports are on the bottom
+}

--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import sbt.Keys.{semanticdbEnabled, semanticdbVersion}
+
 sbtPlugin := true
 
 organization := "net.bzzt"
@@ -41,3 +43,14 @@ scriptedLaunchOpts := {
     Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
 }
 scriptedBufferLog := false
+
+// scalafix specific settings
+inThisBuild(
+  List(
+    semanticdbEnabled := true,
+    semanticdbVersion := scalafixSemanticdb.revision,
+    scalacOptions ++= Seq(
+      "-Ywarn-unused"
+    )
+  )
+)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,5 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.30")
 addSbtPlugin("net.bzzt" % "sbt-strict-scala-versions" % "0.0.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")

--- a/src/main/scala/net/bzzt/reproduciblebuilds/AssemblyHelpers.scala
+++ b/src/main/scala/net/bzzt/reproduciblebuilds/AssemblyHelpers.scala
@@ -16,10 +16,10 @@
 
 package net.bzzt.reproduciblebuilds
 
+import sbt.Keys._
+import sbt._
 import sbtassembly.AssemblyPlugin
 import sbtassembly.AssemblyPlugin.autoImport.{Assembly => _, baseAssemblySettings => _, _}
-import sbt._
-import sbt.Keys._
 
 object AssemblyHelpers {
   val plugin: Plugins.Basic = AssemblyPlugin

--- a/src/main/scala/net/bzzt/reproduciblebuilds/Certification.scala
+++ b/src/main/scala/net/bzzt/reproduciblebuilds/Certification.scala
@@ -16,16 +16,15 @@
 
 package net.bzzt.reproduciblebuilds
 
+import sbt.librarymanagement.ScmInfo
+import sbt.{Artifact, File, ModuleID}
+
 import java.io.StringReader
 import java.math.BigInteger
 import java.nio.file.Files
 import java.security.MessageDigest
 
-import sbt.{Artifact, File, ModuleID}
-import sbt.librarymanagement.ScmInfo
-
-import scala.collection.mutable
-import scala.collection.immutable
+import scala.collection.{immutable, mutable}
 
 case class Checksum(filename: String, length: Int, checksum: List[Byte]) {
   def hexChecksum = checksum.map("%02x" format _).mkString
@@ -58,7 +57,6 @@ case class Certification(
   )
 
   def asPropertyString: String = {
-    val packageName = groupId + ":" + artifactId
     val content = mutable.LinkedHashMap(
       "buildinfo.version" -> "0.1-SNAPSHOT",
       "name" -> name,

--- a/src/main/scala/net/bzzt/reproduciblebuilds/ReproducibleBuildsAssemblyPlugin.scala
+++ b/src/main/scala/net/bzzt/reproduciblebuilds/ReproducibleBuildsAssemblyPlugin.scala
@@ -16,10 +16,10 @@
 
 package net.bzzt.reproduciblebuilds
 
-import scala.util.Try
-
 import sbt._
 import sbt.plugins.JvmPlugin
+
+import scala.util.Try
 
 object ReproducibleBuildsAssemblyPlugin extends AutoPlugin {
   val assemblyPluginOnClasspath =

--- a/src/main/scala/net/bzzt/reproduciblebuilds/SbtLibraryManagementFunctions.scala
+++ b/src/main/scala/net/bzzt/reproduciblebuilds/SbtLibraryManagementFunctions.scala
@@ -1,11 +1,11 @@
 package net.bzzt.reproduciblebuilds
 
 import org.apache.ivy.core.module.descriptor.{
+  Artifact => IArtifact,
   DefaultModuleDescriptor,
   License,
   MDArtifact,
-  ModuleDescriptor,
-  Artifact => IArtifact
+  ModuleDescriptor
 }
 import org.apache.ivy.core.module.id.ModuleRevisionId
 import sbt.librarymanagement.ScalaModuleInfo

--- a/src/main/scala/net/bzzt/reproduciblebuilds/SbtNativePackagerHelpers.scala
+++ b/src/main/scala/net/bzzt/reproduciblebuilds/SbtNativePackagerHelpers.scala
@@ -18,8 +18,8 @@ package net.bzzt.reproduciblebuilds
 
 import com.typesafe.sbt.packager.universal.UniversalPlugin
 import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport._
-import sbt._
 import sbt.Keys._
+import sbt._
 
 /** Helper code for sbt-native-packager integration.
   *

--- a/src/test/scala/CertificationSpec.scala
+++ b/src/test/scala/CertificationSpec.scala
@@ -16,11 +16,6 @@
 
 package net.bzzt.reproduciblebuilds
 
-import java.math.BigInteger
-
-import org.scalatest._
-
-import scala.collection.mutable
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 


### PR DESCRIPTION
Scalafix is an official EPFL scala plugin that lets you do many inspections that is normally delegated to Intellij such as

* Adding types to public members
* Organizing imports (since it uses the actual scalac compiler its not going to have false positives/negatives)
* Remove unused val's that are not referenced

The nice thing is that since this is just an sbt plugin, all of these inspections are not tied to an IDE. Furthermore we can actually check that the code has scalafix applied on CI to prevent it from rotting over time.

As with the scalafmt PR, if there any issues with the config let me know and I can change/rebase PR.

Note that I plan to document this in an upcoming future PR that adds `CONTRIBUTING.md`