### PR TITLE
Remove sbt-strict-scala-versions plugin

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,8 +3,6 @@ addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32+10-1c096efd-SNAPSHOT")
 resolvers += "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
 
-addSbtPlugin("net.bzzt" % "sbt-strict-scala-versions" % "0.0.1")
-
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.12.1")


### PR DESCRIPTION
This is not longer needed, sbt protects against this itself now.