### PR TITLE
Increase report timeout

### DIFF
--- a/src/main/scala/net/bzzt/reproduciblebuilds/ReproducibleBuildsPlugin.scala
+++ b/src/main/scala/net/bzzt/reproduciblebuilds/ReproducibleBuildsPlugin.scala
@@ -405,7 +405,7 @@ object ReproducibleBuildsPlugin extends AutoPlugin {
 
     val targetFilePath = targetDirPath.toPath.resolve("reproducible-builds-report.md")
 
-    Files.write(targetFilePath, Await.result(report, 5.minutes).getBytes(Charset.forName("UTF-8")))
+    Files.write(targetFilePath, Await.result(report, 50.minutes).getBytes(Charset.forName("UTF-8")))
 
     targetFilePath.toFile
   }


### PR DESCRIPTION
Diffoscope runs can also be part of this task, and for large resources these can take a *long* time. sbt provides good feedback, so having a large timeout here can't hurt.