### PR TITLE
update sbt to 1.12.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsPackageNa
 
 /** should work with later sbt versions as well (tested at least with 1.4.x)
   */
-sbtVersion := "1.2.7"
+sbtVersion := "1.12.12"
 
 val sbtPgpVersion = "1.1.2"
 


### PR DESCRIPTION
As a general improvement, but also because `sbt scalafmt` requires 1.12.9+ now