### PR TITLE
fix: substitute organization correctly

### DIFF
--- a/src/main/scala/net/bzzt/reproduciblebuilds/ReproducibleBuildsPlugin.scala
+++ b/src/main/scala/net/bzzt/reproduciblebuilds/ReproducibleBuildsPlugin.scala
@@ -114,7 +114,7 @@ object ReproducibleBuildsPlugin extends AutoPlugin {
   )
   lazy val substituteInfo = Def.task[SubstituteInfo] {
     SubstituteInfo(
-      organization.value.replace('/', '.'),
+      organization.value.replace('.', '/'),
       reproducibleBuildsPackageName.value,
       version.value,
       crossPaths.value,


### PR DESCRIPTION
Got accidentally mixed up in 4c7640f47db63b8749242c4ef319686b34e9d98f